### PR TITLE
fix(docker): convert entrypoint.sh to LF line endings

### DIFF
--- a/data-engineering/.gitattributes
+++ b/data-engineering/.gitattributes
@@ -1,0 +1,2 @@
+# Force LF line endings for shell scripts so Docker containers work on Linux
+*.sh text eol=lf


### PR DESCRIPTION
Windows CRLF caused 'exec /app/entrypoint.sh: no such file or directory' inside the Linux container (shebang read as #!/bin/bash\r).

- Convert entrypoint.sh to LF
- Add .gitattributes to force LF for *.sh files